### PR TITLE
adding env to defaults, will default to elasticache_manage_environmen…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+env: "{{ elasticache_manage_environment }}"
 
 elasticache_manage_memcached: False
 elasticache_manage_redis: False


### PR DESCRIPTION
adding env to defaults, will default to `elasticache_manage_environment` unless env is set by omnia